### PR TITLE
Add title_only option.

### DIFF
--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -68,6 +68,10 @@ type GetNodeMetricsParams struct {
 	// Continue is a pagination token from a previous response.
 	// Used to retrieve the next page of results.
 	Continue string `json:"continue,omitempty"`
+
+	// TitleOnly when true, returns only node names.
+	// When false (default), returns complete node metrics information.
+	TitleOnly *bool `json:"title_only,omitempty"`
 }
 
 // GetPodMetricsParams defines the parameters for the get_pod_metrics MCP tool.
@@ -92,6 +96,10 @@ type GetPodMetricsParams struct {
 	// Continue is a pagination token from a previous response.
 	// Used to retrieve the next page of results.
 	Continue string `json:"continue,omitempty"`
+
+	// TitleOnly when true, returns only pod names.
+	// When false (default), returns complete pod metrics information.
+	TitleOnly *bool `json:"title_only,omitempty"`
 }
 
 // GetNodeMetrics implements the get_node_metrics MCP tool.
@@ -110,6 +118,12 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 		return response.Errorf("failed to create client with context %q: %s", params.Context, err)
 	}
 
+	// Determine whether to show title only (default to false for metrics)
+	titleOnly := false
+	if params.TitleOnly != nil {
+		titleOnly = *params.TitleOnly
+	}
+
 	if params.NodeName != "" {
 		// Get specific node metrics
 		nodeMetrics, err := client.GetNodeMetricsByName(ctx, params.NodeName)
@@ -120,7 +134,14 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 			return response.Errorf("failed to get node metrics for %s: %v", params.NodeName, err)
 		}
 
-		return response.JSON(nodeMetrics)
+		if titleOnly {
+			result := map[string]interface{}{
+				"name": nodeMetrics.Name,
+			}
+			return response.JSON(result)
+		} else {
+			return response.JSON(nodeMetrics)
+		}
 	}
 
 	// Always fetch all node metrics from the server
@@ -130,6 +151,56 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 			return response.Errorf("%s", formatMetricsServerError(err))
 		}
 		return response.Errorf("failed to get node metrics: %v", err)
+	}
+
+	if titleOnly {
+		// Return only node names
+		var nodeNames []string
+		for _, nodeMetrics := range nodeMetricsList.Items {
+			nodeNames = append(nodeNames, nodeMetrics.Name)
+		}
+
+		// Sort names alphabetically for consistency
+		sort.Strings(nodeNames)
+
+		// Handle pagination for names only
+		if params.Limit > 0 {
+			paginationState, err := parseContinueToken(params.Continue)
+			if err != nil {
+				return response.Errorf("invalid continue token: %v", err)
+			}
+
+			// Convert to interface slice for pagination
+			allItems := make([]interface{}, len(nodeNames))
+			for i, name := range nodeNames {
+				allItems[i] = name
+			}
+
+			paginatedItems, hasMore := paginateItems(allItems, params.Limit, paginationState.Offset)
+
+			result := map[string]interface{}{
+				"kind":       "NodeMetricsList",
+				"apiVersion": "metrics.k8s.io/v1beta1",
+				"count":      len(paginatedItems),
+				"items":      paginatedItems,
+			}
+
+			if hasMore {
+				nextOffset := paginationState.Offset + params.Limit
+				result["continue"] = generateContinueToken(nextOffset, "node", "")
+			}
+
+			return response.JSON(result)
+		} else {
+			result := map[string]interface{}{
+				"kind":       "NodeMetricsList",
+				"apiVersion": "metrics.k8s.io/v1beta1",
+				"count":      len(nodeNames),
+				"items":      nodeNames,
+			}
+
+			return response.JSON(result)
+		}
 	}
 
 	// Convert to interface slice for client-side pagination
@@ -199,6 +270,12 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
 	}
 
+	// Determine whether to show title only (default to false for metrics)
+	titleOnly := false
+	if params.TitleOnly != nil {
+		titleOnly = *params.TitleOnly
+	}
+
 	if params.PodName != "" {
 		// Get specific pod metrics
 		if params.Namespace == "" {
@@ -213,7 +290,15 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 			return response.Errorf("failed to get pod metrics for %s/%s: %v", params.Namespace, params.PodName, err)
 		}
 
-		return response.JSON(podMetrics)
+		if titleOnly {
+			result := map[string]interface{}{
+				"name":      podMetrics.Name,
+				"namespace": podMetrics.Namespace,
+			}
+			return response.JSON(result)
+		} else {
+			return response.JSON(podMetrics)
+		}
 	}
 
 	// Always fetch all pod metrics from the server
@@ -232,6 +317,80 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 			return response.Errorf("%s", formatMetricsServerError(err))
 		}
 		return response.Errorf("failed to get pod metrics: %v", err)
+	}
+
+	if titleOnly {
+		// Return only pod names with namespaces
+		type PodName struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		}
+		var podNames []PodName
+		for _, podMetrics := range podMetricsList.Items {
+			podNames = append(podNames, PodName{
+				Name:      podMetrics.Name,
+				Namespace: podMetrics.Namespace,
+			})
+		}
+
+		// Sort by namespace then name for consistency
+		sort.Slice(podNames, func(i, j int) bool {
+			if podNames[i].Namespace != podNames[j].Namespace {
+				return podNames[i].Namespace < podNames[j].Namespace
+			}
+			return podNames[i].Name < podNames[j].Name
+		})
+
+		// Handle pagination for names only
+		if params.Limit > 0 {
+			paginationState, err := parseContinueToken(params.Continue)
+			if err != nil {
+				return response.Errorf("invalid continue token: %v", err)
+			}
+
+			// Validate that the continue token is for the same request type
+			if paginationState.Type != "" && paginationState.Type != "pod" {
+				return response.Error("continue token is not valid for pod metrics")
+			}
+
+			// Reset pagination if namespace context has changed
+			if paginationState.Namespace != params.Namespace {
+				paginationState.Offset = 0
+			}
+
+			// Convert to interface slice for pagination
+			allItems := make([]interface{}, len(podNames))
+			for i, podName := range podNames {
+				allItems[i] = podName
+			}
+
+			paginatedItems, hasMore := paginateItems(allItems, params.Limit, paginationState.Offset)
+
+			result := map[string]interface{}{
+				"kind":       "PodMetricsList",
+				"apiVersion": "metrics.k8s.io/v1beta1",
+				"namespace":  params.Namespace,
+				"count":      len(paginatedItems),
+				"items":      paginatedItems,
+			}
+
+			if hasMore {
+				nextOffset := paginationState.Offset + params.Limit
+				result["continue"] = generateContinueToken(nextOffset, "pod", params.Namespace)
+			}
+
+			return response.JSON(result)
+		} else {
+			result := map[string]interface{}{
+				"kind":       "PodMetricsList",
+				"apiVersion": "metrics.k8s.io/v1beta1",
+				"namespace":  params.Namespace,
+				"count":      len(podNames),
+				"items":      podNames,
+			}
+
+			return response.JSON(result)
+		}
 	}
 
 	// Convert to interface slice for client-side pagination
@@ -359,7 +518,7 @@ func (h *MetricsHandler) GetTools() []MCPTool {
 	return []MCPTool{
 		NewMCPTool(
 			mcp.NewTool("get_node_metrics",
-				mcp.WithDescription("Get node metrics (CPU and memory usage)"),
+				mcp.WithDescription("Get node metrics (CPU and memory usage). Returns complete metrics by default (title_only=false), or only node names when title_only=true"),
 				mcp.WithString("node_name",
 					mcp.Description("Specific node name to get metrics for (optional - if not provided, returns metrics for all nodes)"),
 				),
@@ -372,12 +531,15 @@ func (h *MetricsHandler) GetTools() []MCPTool {
 				mcp.WithString("continue",
 					mcp.Description("Continue token for pagination (optional - from previous response)"),
 				),
+				mcp.WithBoolean("title_only",
+					mcp.Description("When true, returns only node names. When false (default), returns complete node metrics"),
+				),
 			),
 			h.GetNodeMetrics,
 		),
 		NewMCPTool(
 			mcp.NewTool("get_pod_metrics",
-				mcp.WithDescription("Get pod metrics (CPU and memory usage)"),
+				mcp.WithDescription("Get pod metrics (CPU and memory usage). Returns complete metrics by default (title_only=false), or only pod names with namespaces when title_only=true"),
 				mcp.WithString("namespace",
 					mcp.Description("Namespace to get pod metrics from (optional - if not provided, returns metrics for all pods)"),
 				),
@@ -392,6 +554,9 @@ func (h *MetricsHandler) GetTools() []MCPTool {
 				),
 				mcp.WithString("continue",
 					mcp.Description("Continue token for pagination (optional - from previous response)"),
+				),
+				mcp.WithBoolean("title_only",
+					mcp.Description("When true, returns only pod names with namespaces. When false (default), returns complete pod metrics"),
 				),
 			),
 			h.GetPodMetrics,

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -139,9 +139,8 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 				"name": nodeMetrics.Name,
 			}
 			return response.JSON(result)
-		} else {
-			return response.JSON(nodeMetrics)
 		}
+		return response.JSON(nodeMetrics)
 	}
 
 	// Always fetch all node metrics from the server
@@ -156,8 +155,8 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	if titleOnly {
 		// Return only node names
 		var nodeNames []string
-		for _, nodeMetrics := range nodeMetricsList.Items {
-			nodeNames = append(nodeNames, nodeMetrics.Name)
+		for i := range nodeMetricsList.Items {
+			nodeNames = append(nodeNames, nodeMetricsList.Items[i].Name)
 		}
 
 		// Sort names alphabetically for consistency
@@ -191,16 +190,16 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 			}
 
 			return response.JSON(result)
-		} else {
-			result := map[string]interface{}{
-				"kind":       "NodeMetricsList",
-				"apiVersion": "metrics.k8s.io/v1beta1",
-				"count":      len(nodeNames),
-				"items":      nodeNames,
-			}
-
-			return response.JSON(result)
 		}
+
+		result := map[string]interface{}{
+			"kind":       "NodeMetricsList",
+			"apiVersion": "metrics.k8s.io/v1beta1",
+			"count":      len(nodeNames),
+			"items":      nodeNames,
+		}
+
+		return response.JSON(result)
 	}
 
 	// Convert to interface slice for client-side pagination
@@ -296,9 +295,8 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 				"namespace": podMetrics.Namespace,
 			}
 			return response.JSON(result)
-		} else {
-			return response.JSON(podMetrics)
 		}
+		return response.JSON(podMetrics)
 	}
 
 	// Always fetch all pod metrics from the server
@@ -326,10 +324,10 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 			Namespace string `json:"namespace"`
 		}
 		var podNames []PodName
-		for _, podMetrics := range podMetricsList.Items {
+		for i := range podMetricsList.Items {
 			podNames = append(podNames, PodName{
-				Name:      podMetrics.Name,
-				Namespace: podMetrics.Namespace,
+				Name:      podMetricsList.Items[i].Name,
+				Namespace: podMetricsList.Items[i].Namespace,
 			})
 		}
 
@@ -380,17 +378,17 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 			}
 
 			return response.JSON(result)
-		} else {
-			result := map[string]interface{}{
-				"kind":       "PodMetricsList",
-				"apiVersion": "metrics.k8s.io/v1beta1",
-				"namespace":  params.Namespace,
-				"count":      len(podNames),
-				"items":      podNames,
-			}
-
-			return response.JSON(result)
 		}
+
+		result := map[string]interface{}{
+			"kind":       "PodMetricsList",
+			"apiVersion": "metrics.k8s.io/v1beta1",
+			"namespace":  params.Namespace,
+			"count":      len(podNames),
+			"items":      podNames,
+		}
+
+		return response.JSON(result)
 	}
 
 	// Convert to interface slice for client-side pagination

--- a/internal/handlers/resources.go
+++ b/internal/handlers/resources.go
@@ -358,46 +358,46 @@ func (h *ResourceHandler) ListAPIResources(ctx context.Context, request mcp.Call
 		}
 
 		return response.JSON(result)
-	} else {
-		// Return full API resource information
-		var resources []APIResource
+	}
 
-		for _, list := range lists {
-			_, err := schema.ParseGroupVersion(list.GroupVersion)
-			if err != nil {
+	// Return full API resource information
+	var resources []APIResource
+
+	for _, list := range lists {
+		_, err := schema.ParseGroupVersion(list.GroupVersion)
+		if err != nil {
+			continue
+		}
+
+		for i := range list.APIResources {
+			resource := &list.APIResources[i]
+			if strings.Contains(resource.Name, "/") {
 				continue
 			}
 
-			for i := range list.APIResources {
-				resource := &list.APIResources[i]
-				if strings.Contains(resource.Name, "/") {
-					continue
-				}
-
-				resources = append(resources, APIResource{
-					Name:         resource.Name,
-					SingularName: resource.SingularName,
-					Namespaced:   resource.Namespaced,
-					Kind:         resource.Kind,
-					Verbs:        resource.Verbs,
-					ShortNames:   resource.ShortNames,
-					APIVersion:   list.GroupVersion,
-					Categories:   resource.Categories,
-				})
-			}
+			resources = append(resources, APIResource{
+				Name:         resource.Name,
+				SingularName: resource.SingularName,
+				Namespaced:   resource.Namespaced,
+				Kind:         resource.Kind,
+				Verbs:        resource.Verbs,
+				ShortNames:   resource.ShortNames,
+				APIVersion:   list.GroupVersion,
+				Categories:   resource.Categories,
+			})
 		}
-
-		sort.Slice(resources, func(i, j int) bool {
-			return resources[i].Name < resources[j].Name
-		})
-
-		result := map[string]interface{}{
-			"resources": resources,
-			"count":     len(resources),
-		}
-
-		return response.JSON(result)
 	}
+
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i].Name < resources[j].Name
+	})
+
+	result := map[string]interface{}{
+		"resources": resources,
+		"count":     len(resources),
+	}
+
+	return response.JSON(result)
 }
 
 // ListContexts implements the list_contexts MCP tool.
@@ -439,15 +439,15 @@ func (h *ResourceHandler) ListContexts(_ context.Context, request mcp.CallToolRe
 		}
 
 		return response.JSON(result)
-	} else {
-		// Return complete context information
-		result := map[string]interface{}{
-			"contexts": contexts,
-			"count":    len(contexts),
-		}
-
-		return response.JSON(result)
 	}
+
+	// Return complete context information
+	result := map[string]interface{}{
+		"contexts": contexts,
+		"count":    len(contexts),
+	}
+
+	return response.JSON(result)
 }
 
 // GetTools returns all resource-related MCP tools provided by this handler.
@@ -485,6 +485,7 @@ func (h *ResourceHandler) GetTools() []MCPTool {
 				),
 				mcp.WithBoolean("title_only",
 					mcp.Description("When true (default), returns only resource names. When false, returns metadata, apiVersion, and kind"),
+					mcp.DefaultBool(true),
 				),
 			),
 			h.ListResources,
@@ -517,6 +518,7 @@ func (h *ResourceHandler) GetTools() []MCPTool {
 				mcp.WithDescription("List available Kubernetes API resources. Returns only resource names by default (title_only=true), or complete details when title_only=false (similar to kubectl api-resources)"),
 				mcp.WithBoolean("title_only",
 					mcp.Description("When true (default), returns only resource names. When false, returns complete API resource details"),
+					mcp.DefaultBool(true),
 				),
 			),
 			h.ListAPIResources,


### PR DESCRIPTION
To overcome some limitations of Claude Desktop's context window being super tiny, this allows AI to query lists by just finding names, and if they need to do so, they can pull full responses if needed.