### PR TITLE
Add --always-start flag to skip startup connectivity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Add the following configuration to your editor's settings to use `mcp-kubernetes
         // "--transport=stdio",
         // "--port=8080",
         // "--disabled-tools=get_logs,decode_base64",
-        // "--disabled-resources=secrets"
+        // "--disabled-resources=secrets",
+        // "--always-start"
       ],
       "env": {
         // Set KUBECONFIG environment variable if needed:
@@ -73,7 +74,9 @@ Add the following configuration to your editor's settings to use `mcp-kubernetes
         // Or use generic DISABLED_TOOLS environment variable:
         // "DISABLED_TOOLS": "get_logs,decode_base64",
         // Disable access to specific resource types:
-        // "MCP_KUBERNETES_RO_DISABLED_RESOURCES": "secrets,configmaps"
+        // "MCP_KUBERNETES_RO_DISABLED_RESOURCES": "secrets,configmaps",
+        // Skip startup connectivity check via environment variable:
+        // "MCP_KUBERNETES_RO_ALWAYS_START": "true"
       }
     }
   }
@@ -936,7 +939,19 @@ If the connectivity check fails, you'll see a detailed error message. Common iss
 - **Authentication failed**: Ensure your credentials haven't expired and are valid
 - **Insufficient permissions**: Verify you have at least read access to basic cluster resources
 
-The connectivity check has a 30-second timeout to prevent hanging on unresponsive clusters.
+The connectivity check has a 10-second timeout to prevent hanging on unresponsive clusters.
+
+### Skipping the Connectivity Check (`--always-start`)
+
+If your credentials are granted via an OIDC browser-flow or another mechanism where the token is not yet valid when the MCP server process starts, use the `--always-start` flag (or `MCP_KUBERNETES_RO_ALWAYS_START=true` environment variable) to skip the startup connectivity check entirely:
+
+```bash
+mcp-kubernetes-ro --always-start
+```
+
+With `--always-start`, the server starts immediately without contacting the cluster. The connectivity check is effectively deferred: the first time a tool is called, it will attempt to reach the cluster normally. If the cluster is unreachable or the credentials have expired at that point, the tool will return a structured error message to the AI instructing it not to retry automatically and to prompt you to re-authenticate.
+
+Resource filters configured via `--disabled-resources` are similarly deferred: name resolution happens on the first tool call rather than at startup, so no cluster connection is required to start the server.
 
 ## Security Considerations
 

--- a/internal/connectivity/errors.go
+++ b/internal/connectivity/errors.go
@@ -1,0 +1,69 @@
+package connectivity
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsError reports whether err looks like a transient connectivity
+// or authentication failure rather than an application-level error. This is
+// used by tool handlers to decide whether to emit a "do not retry" message
+// to the LLM when --always-start is in use and the cluster is unreachable.
+func IsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	s := strings.ToLower(err.Error())
+
+	patterns := []string{
+		// Network-level failures
+		"connection refused",
+		"connection reset",
+		"connection timed out",
+		"no such host",
+		"i/o timeout",
+		"dial tcp",
+		"no route to host",
+		"network is unreachable",
+		// TLS / certificate errors
+		"tls handshake",
+		"x509:",
+		"certificate",
+		// Auth / token errors
+		"unauthorized",
+		"401 unauthorized",
+		"403 forbidden",
+		"token has expired",
+		"id token",
+		"oidc",
+		"credentials",
+		// Context / timeout
+		"context deadline exceeded",
+		// Unexpected EOF often signals the server dropped the connection
+		"unexpected eof",
+	}
+
+	for _, p := range patterns {
+		if strings.Contains(s, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ErrorMessage returns a formatted message suitable for returning to an LLM
+// via a tool error result. It includes the underlying error and explicit
+// guidance not to retry the request automatically.
+func ErrorMessage(err error) string {
+	return fmt.Sprintf(
+		"Failed to reach the Kubernetes cluster: %v\n\n"+
+			"This appears to be a connectivity or authentication problem. "+
+			"Do not retry this request automatically — instead, let the user know they may need to:\n"+
+			"  • Refresh their credentials (e.g. re-run the OIDC browser login flow)\n"+
+			"  • Verify the cluster endpoint is reachable from this machine\n"+
+			"  • Check that their kubeconfig is valid and up to date",
+		err,
+	)
+}

--- a/internal/connectivity/errors.go
+++ b/internal/connectivity/errors.go
@@ -1,56 +1,99 @@
 package connectivity
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
-	"strings"
+	"io"
+	"net"
+	"net/url"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// IsError reports whether err looks like a transient connectivity
-// or authentication failure rather than an application-level error. This is
-// used by tool handlers to decide whether to emit a "do not retry" message
-// to the LLM when --always-start is in use and the cluster is unreachable.
-func IsError(err error) bool {
+// IsTransportError reports whether err is a pre-connection or transport-level
+// failure: the request never reached the API server, or the TLS/network layer
+// broke before a structured response was received. These errors are always
+// unambiguously a connectivity or configuration problem.
+//
+// Use this at call sites that perform live API calls (list, get, logs, metrics,
+// port-forward) where a structured API response like 403 Forbidden would be a
+// legitimate application-level result, not a connectivity problem.
+func IsTransportError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	s := strings.ToLower(err.Error())
-
-	patterns := []string{
-		// Network-level failures
-		"connection refused",
-		"connection reset",
-		"connection timed out",
-		"no such host",
-		"i/o timeout",
-		"dial tcp",
-		"no route to host",
-		"network is unreachable",
-		// TLS / certificate errors
-		"tls handshake",
-		"x509:",
-		"certificate",
-		// Auth / token errors
-		"unauthorized",
-		"401 unauthorized",
-		"403 forbidden",
-		"token has expired",
-		"id token",
-		"oidc",
-		"credentials",
-		// Context / timeout
-		"context deadline exceeded",
-		// Unexpected EOF often signals the server dropped the connection
-		"unexpected eof",
+	// Context deadline - the request did not complete within its allowed time.
+	// context.Canceled is intentionally excluded: it also fires when the MCP
+	// client cancels a tool call (e.g. user presses stop), so treating it as a
+	// connectivity failure would mislead the user.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
 	}
 
-	for _, p := range patterns {
-		if strings.Contains(s, p) {
-			return true
-		}
+	// Unexpected EOF means the server dropped the connection mid-response
+	// without sending a complete, parseable reply. Plain io.EOF is excluded
+	// because it is the normal end-of-stream signal for log streaming.
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// Network-level errors. *url.Error is the outermost wrapper produced by
+	// the HTTP transport and covers exec-credential failures (e.g. OIDC browser
+	// flow errors), connection refused, DNS failures, and TLS handshake errors.
+	var netErr *net.OpError
+	var dnsErr *net.DNSError
+	var urlErr *url.Error
+	var tlsRecordErr tls.RecordHeaderError
+
+	if errors.As(err, &netErr) || errors.As(err, &dnsErr) ||
+		errors.As(err, &urlErr) || errors.As(err, &tlsRecordErr) {
+		return true
+	}
+
+	// TLS / x509 certificate errors - can appear in OIDC scenarios when the
+	// cluster CA or the OIDC provider certificate is invalid, expired, or
+	// self-signed. These are caught separately because they may be unwrapped
+	// from a *url.Error in some code paths.
+	var certInvalidErr x509.CertificateInvalidError
+	var hostnameErr x509.HostnameError
+	var unknownAuthErr x509.UnknownAuthorityError
+
+	if errors.As(err, &certInvalidErr) || errors.As(err, &hostnameErr) ||
+		errors.As(err, &unknownAuthErr) {
+		return true
 	}
 
 	return false
+}
+
+// IsAuthError reports whether err is a structured Kubernetes API-level
+// authentication failure (HTTP 401). Unlike 403 Forbidden, which may mean the
+// user is authenticated but simply lacks RBAC access to a specific resource, a
+// 401 always means the credentials themselves are invalid or expired.
+//
+// Use this together with IsTransportError at call sites where hitting the API
+// server at all requires valid credentials (e.g. discovery, resource filter
+// initialisation) and a 401 is indistinguishable from a connectivity failure
+// from the user's perspective.
+func IsAuthError(err error) bool {
+	return apierrors.IsUnauthorized(err)
+}
+
+// IsError reports whether err is either a transport-level connectivity failure
+// or an API-level authentication error. It is a convenience combinator of
+// IsTransportError and IsAuthError.
+//
+// Use this only at call sites where both kinds of error should be treated as
+// "the cluster is unreachable or credentials are invalid", such as during API
+// discovery or lazy resource filter initialisation. Prefer IsTransportError
+// alone for call sites that perform ordinary resource reads, where a 401 or
+// 403 may be a legitimate RBAC response rather than a connectivity problem.
+func IsError(err error) bool {
+	return IsTransportError(err) || IsAuthError(err)
 }
 
 // ErrorMessage returns a formatted message suitable for returning to an LLM
@@ -60,7 +103,7 @@ func ErrorMessage(err error) string {
 	return fmt.Sprintf(
 		"Failed to reach the Kubernetes cluster: %v\n\n"+
 			"This appears to be a connectivity or authentication problem. "+
-			"Do not retry this request automatically — instead, let the user know they may need to:\n"+
+			"Do not retry this request automatically - instead, let the user know they may need to:\n"+
 			"  • Refresh their credentials (e.g. re-run the OIDC browser login flow)\n"+
 			"  • Verify the cluster endpoint is reachable from this machine\n"+
 			"  • Check that their kubeconfig is valid and up to date",

--- a/internal/connectivity/errors_test.go
+++ b/internal/connectivity/errors_test.go
@@ -1,0 +1,383 @@
+package connectivity
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+var (
+	listAll = metav1.ListOptions{}
+	getOpts = metav1.GetOptions{}
+)
+
+// podGR is a GroupResource used when constructing typed API errors.
+var podGR = schema.GroupResource{Group: "", Resource: "pods"}
+
+// injectError returns a fake clientset whose first reaction always returns
+// the provided error. This proves that the apierrors predicates still work
+// on *StatusError values after they travel through the fake client's reactor
+// chain - just as they would from a real API server response.
+func injectError(err error) *kubefake.Clientset {
+	cs := kubefake.NewClientset()
+	cs.PrependReactor("*", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, err
+	})
+	return cs
+}
+
+// oidcExecErr simulates the error produced when an exec credential plugin
+// (e.g. kubectl-oidc_login) fails during a token refresh. The HTTP transport
+// always wraps such failures in a *url.Error, so IsTransportError must detect
+// it via errors.As rather than string matching.
+var oidcExecErr = &url.Error{
+	Op:  "Get",
+	URL: "https://cluster.example.com/api?timeout=32s",
+	Err: errors.New(
+		"getting credentials: exec: executable kubectl-oidc_login failed with exit code 1",
+	),
+}
+
+// TestIsTransportError covers errors that are definitively pre-connection or
+// transport-level failures. It also verifies that structured API-level errors
+// (401, 403, 503 etc.) and normal end-of-stream signals are NOT caught here,
+// so they can be handled (or passed through) accurately at the call site.
+func TestIsTransportError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// nil is never an error.
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+
+		// Plain application errors must not be misclassified.
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("pod %q not found", "my-pod"),
+			want: false,
+		},
+
+		// --- Structured Kubernetes API errors must NOT be caught ---
+		// These are legitimate API responses; catching them as "connectivity
+		// errors" would mislead the user into thinking they need to re-authenticate
+		// when actually the cluster is reachable and the request itself failed.
+		{
+			name: "apierrors.IsUnauthorized - caught by IsAuthError, not here",
+			err:  apierrors.NewUnauthorized("token has expired"),
+			want: false,
+		},
+		{
+			name: "apierrors.IsForbidden - valid RBAC denial, not a transport error",
+			err:  apierrors.NewForbidden(podGR, "secrets", errors.New("not allowed")),
+			want: false,
+		},
+		{
+			name: "apierrors.IsServiceUnavailable - partial cluster failure, not transport",
+			err:  apierrors.NewServiceUnavailable("metrics-server not ready"),
+			want: false,
+		},
+		{
+			name: "apierrors.IsNotFound - resource does not exist",
+			err:  apierrors.NewNotFound(podGR, "my-pod"),
+			want: false,
+		},
+		// Via fake client reactor - confirms the *StatusError survives the reactor chain.
+		{
+			name: "apierrors.IsForbidden via fake clientset reactor",
+			err: func() error {
+				cs := injectError(apierrors.NewForbidden(podGR, "secrets", errors.New("denied")))
+				_, err := cs.CoreV1().Pods("default").List(context.Background(), listAll)
+				return err
+			}(),
+			want: false,
+		},
+		{
+			name: "apierrors.IsNotFound via fake clientset reactor",
+			err: func() error {
+				cs := injectError(apierrors.NewNotFound(podGR, "my-pod"))
+				_, err := cs.CoreV1().Pods("default").Get(context.Background(), "my-pod", getOpts)
+				return err
+			}(),
+			want: false,
+		},
+
+		// --- context.Canceled must NOT be caught ---
+		// It also fires when the MCP client cancels a tool call (user presses stop),
+		// so treating it as a connectivity failure would mislead the user.
+		{
+			name: "context.Canceled - user aborted, not a connectivity failure",
+			err:  context.Canceled,
+			want: false,
+		},
+
+		// --- io.EOF must NOT be caught ---
+		// It is the normal end-of-stream signal for log streaming; treating it as
+		// a transport error would misclassify a completed log stream.
+		{
+			name: "io.EOF - normal end of log stream",
+			err:  io.EOF,
+			want: false,
+		},
+
+		// --- Errors that ARE transport-level failures ---
+
+		// Context deadline.
+		{
+			name: "context.DeadlineExceeded",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "context.DeadlineExceeded wrapped",
+			err:  fmt.Errorf("operation failed: %w", context.DeadlineExceeded),
+			want: true,
+		},
+
+		// Unexpected EOF: server dropped the connection mid-response.
+		{
+			name: "io.ErrUnexpectedEOF",
+			err:  io.ErrUnexpectedEOF,
+			want: true,
+		},
+		{
+			name: "io.ErrUnexpectedEOF wrapped",
+			err:  fmt.Errorf("reading response: %w", io.ErrUnexpectedEOF),
+			want: true,
+		},
+
+		// Network-level errors.
+		{
+			name: "net.OpError - connection refused",
+			err: &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: errors.New("connection refused"),
+			},
+			want: true,
+		},
+		{
+			name: "net.DNSError - no such host",
+			err: &net.DNSError{
+				Err:  "no such host",
+				Name: "cluster.example.internal",
+			},
+			want: true,
+		},
+		{
+			name: "url.Error - generic HTTP transport failure",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://cluster.example.com/api",
+				Err: errors.New("connection refused"),
+			},
+			want: true,
+		},
+		{
+			// Real-world OIDC exec-credential failure: surfaces as a *url.Error
+			// wrapping a plain string from the exec plugin. Must be caught via
+			// errors.As, not string matching.
+			name: "url.Error - OIDC exec credential plugin failure",
+			err:  oidcExecErr,
+			want: true,
+		},
+		{
+			name: "tls.RecordHeaderError - bad TLS record from server",
+			err: tls.RecordHeaderError{
+				Msg: "first record does not look like a TLS handshake",
+			},
+			want: true,
+		},
+
+		// x509 / certificate errors - can appear in OIDC scenarios when the
+		// cluster CA or OIDC provider cert is invalid, expired, or self-signed.
+		{
+			name: "x509.UnknownAuthorityError - self-signed or unknown CA",
+			err:  x509.UnknownAuthorityError{},
+			want: true,
+		},
+		{
+			name: "x509.CertificateInvalidError - expired certificate",
+			err: x509.CertificateInvalidError{
+				Reason: x509.Expired,
+			},
+			want: true,
+		},
+		{
+			name: "x509.HostnameError - certificate hostname mismatch",
+			err: x509.HostnameError{
+				Host: "cluster.example.com",
+			},
+			want: true,
+		},
+		{
+			name: "x509.UnknownAuthorityError wrapped in url.Error",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://cluster.example.com/api",
+				Err: x509.UnknownAuthorityError{},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsTransportError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsTransportError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAuthError covers the single structured API error that IsAuthError
+// recognises (HTTP 401). It also confirms that 403 Forbidden - a legitimate
+// RBAC denial - is NOT treated as an auth error requiring re-authentication.
+func TestIsAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("some random error"),
+			want: false,
+		},
+		// 401 Unauthorized always means credentials are invalid or expired.
+		{
+			name: "apierrors.IsUnauthorized - token expired",
+			err:  apierrors.NewUnauthorized("token has expired"),
+			want: true,
+		},
+		{
+			// Via fake client reactor: confirms *StatusError survives the reactor chain.
+			name: "apierrors.IsUnauthorized via fake clientset reactor",
+			err: func() error {
+				cs := injectError(apierrors.NewUnauthorized("bad token"))
+				_, err := cs.CoreV1().Pods("default").List(context.Background(), listAll)
+				return err
+			}(),
+			want: true,
+		},
+		// 403 Forbidden is a legitimate RBAC response, NOT an auth error.
+		// The user is authenticated; they simply lack access to the resource.
+		// Returning a connectivity/re-auth message here would mislead the user.
+		{
+			name: "apierrors.IsForbidden - valid RBAC denial, not an auth error",
+			err:  apierrors.NewForbidden(podGR, "secrets", errors.New("not allowed")),
+			want: false,
+		},
+		{
+			name: "apierrors.IsForbidden via fake clientset reactor",
+			err: func() error {
+				cs := injectError(apierrors.NewForbidden(podGR, "secrets", errors.New("denied")))
+				_, err := cs.CoreV1().Pods("default").List(context.Background(), listAll)
+				return err
+			}(),
+			want: false,
+		},
+		// Other structured API errors are also not auth errors.
+		{
+			name: "apierrors.IsServiceUnavailable",
+			err:  apierrors.NewServiceUnavailable("not ready"),
+			want: false,
+		},
+		{
+			name: "apierrors.IsNotFound",
+			err:  apierrors.NewNotFound(podGR, "my-pod"),
+			want: false,
+		},
+		// Transport errors are handled by IsTransportError, not here.
+		{
+			name: "net.OpError",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAuthError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsError confirms that IsError is the union of IsTransportError and
+// IsAuthError, and that errors which are false for both are also false for IsError.
+func TestIsError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "unrelated error", err: fmt.Errorf("not found"), want: false},
+		// Transport errors → true.
+		{name: "net.OpError", err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("refused")}, want: true},
+		{name: "context.DeadlineExceeded", err: context.DeadlineExceeded, want: true},
+		{name: "io.ErrUnexpectedEOF", err: io.ErrUnexpectedEOF, want: true},
+		{name: "url.Error (OIDC)", err: oidcExecErr, want: true},
+		// Auth errors → true.
+		{name: "apierrors.IsUnauthorized", err: apierrors.NewUnauthorized("expired"), want: true},
+		// Errors that are neither → false, confirming no false positives.
+		{name: "apierrors.IsForbidden - RBAC denial", err: apierrors.NewForbidden(podGR, "secrets", errors.New("no")), want: false},
+		{name: "apierrors.IsServiceUnavailable", err: apierrors.NewServiceUnavailable("down"), want: false},
+		{name: "apierrors.IsNotFound", err: apierrors.NewNotFound(podGR, "x"), want: false},
+		{name: "context.Canceled - user abort", err: context.Canceled, want: false},
+		{name: "io.EOF - normal log stream end", err: io.EOF, want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestErrorMessage_ContainsError(t *testing.T) {
+	err := apierrors.NewUnauthorized("token has expired")
+	msg := ErrorMessage(err)
+
+	if msg == "" {
+		t.Fatal("ErrorMessage returned empty string")
+	}
+
+	// The message must embed the underlying error text so the LLM has context.
+	if !strings.Contains(msg, err.Error()) {
+		t.Errorf("ErrorMessage does not contain underlying error text %q\ngot: %s", err.Error(), msg)
+	}
+}

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -17,13 +17,18 @@ import (
 // It supports advanced log filtering with grep-like capabilities, time-based filtering,
 // container selection in multi-container pods, and access to previous container logs.
 type LogHandler struct {
-	client *kubernetes.Client
+	client      *kubernetes.Client
+	alwaysStart bool
 }
 
 // NewLogHandler creates a new LogHandler with the provided Kubernetes client.
-func NewLogHandler(client *kubernetes.Client) *LogHandler {
+// alwaysStart mirrors the --always-start flag: when true, connectivity and auth errors
+// are intercepted and returned as structured tool errors so the LLM can surface them
+// to the user rather than treating them as retryable failures.
+func NewLogHandler(client *kubernetes.Client, alwaysStart bool) *LogHandler {
 	return &LogHandler{
-		client: client,
+		client:      client,
+		alwaysStart: alwaysStart,
 	}
 }
 
@@ -76,7 +81,7 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -134,7 +139,7 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Get logs
 	logs, err := client.GetPodLogsWithOptions(ctx, params.Namespace, params.Name, logOpts)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to get pod logs: %w", err)
@@ -198,7 +203,7 @@ func (h *LogHandler) GetPodContainers(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
@@ -206,7 +211,7 @@ func (h *LogHandler) GetPodContainers(ctx context.Context, request mcp.CallToolR
 
 	containers, err := client.GetPodContainers(ctx, params.Namespace, params.Name)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to get pod containers: %w", err)

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/connectivity"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/kubernetes"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/logfilter"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/response"
@@ -75,6 +76,9 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
 	}
 
@@ -130,6 +134,9 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Get logs
 	logs, err := client.GetPodLogsWithOptions(ctx, params.Namespace, params.Name, logOpts)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to get pod logs: %w", err)
 	}
 
@@ -191,11 +198,17 @@ func (h *LogHandler) GetPodContainers(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
 	}
 
 	containers, err := client.GetPodContainers(ctx, params.Namespace, params.Name)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to get pod containers: %w", err)
 	}
 

--- a/internal/handlers/logs.go
+++ b/internal/handlers/logs.go
@@ -76,10 +76,10 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
-		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
+		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
 	}
 
 	// Set max lines
@@ -134,7 +134,7 @@ func (h *LogHandler) GetLogs(ctx context.Context, request mcp.CallToolRequest) (
 	// Get logs
 	logs, err := client.GetPodLogsWithOptions(ctx, params.Namespace, params.Name, logOpts)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to get pod logs: %w", err)
@@ -198,7 +198,7 @@ func (h *LogHandler) GetPodContainers(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
@@ -206,7 +206,7 @@ func (h *LogHandler) GetPodContainers(ctx context.Context, request mcp.CallToolR
 
 	containers, err := client.GetPodContainers(ctx, params.Namespace, params.Name)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to get pod containers: %w", err)

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -20,13 +20,18 @@ import (
 // The handler supports both cluster-wide and targeted metrics retrieval with
 // client-side pagination for consistent ordering and performance.
 type MetricsHandler struct {
-	client *kubernetes.Client
+	client      *kubernetes.Client
+	alwaysStart bool
 }
 
 // NewMetricsHandler creates a new MetricsHandler with the provided Kubernetes client.
-func NewMetricsHandler(client *kubernetes.Client) *MetricsHandler {
+// alwaysStart mirrors the --always-start flag: when true, connectivity and auth errors
+// are intercepted and returned as structured tool errors so the LLM can surface them
+// to the user rather than treating them as retryable failures.
+func NewMetricsHandler(client *kubernetes.Client, alwaysStart bool) *MetricsHandler {
 	return &MetricsHandler{
-		client: client,
+		client:      client,
+		alwaysStart: alwaysStart,
 	}
 }
 
@@ -116,7 +121,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %q: %s", params.Context, err)
@@ -132,7 +137,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 		// Get specific node metrics
 		nodeMetrics, err := client.GetNodeMetricsByName(ctx, params.NodeName)
 		if err != nil {
-			if connectivity.IsTransportError(err) {
+			if h.alwaysStart && connectivity.IsTransportError(err) {
 				return response.Error(connectivity.ErrorMessage(err))
 			}
 			if isMetricsServerError(err) {
@@ -153,7 +158,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Always fetch all node metrics from the server
 	nodeMetricsList, err := client.GetNodeMetrics(ctx)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		if isMetricsServerError(err) {
@@ -276,7 +281,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -296,7 +301,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 
 		podMetrics, err := client.GetPodMetricsByName(ctx, params.Namespace, params.PodName)
 		if err != nil {
-			if connectivity.IsTransportError(err) {
+			if h.alwaysStart && connectivity.IsTransportError(err) {
 				return response.Error(connectivity.ErrorMessage(err))
 			}
 			if isMetricsServerError(err) {
@@ -327,7 +332,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	}
 
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		if isMetricsServerError(err) {

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -116,7 +116,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %q: %s", params.Context, err)
@@ -132,7 +132,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 		// Get specific node metrics
 		nodeMetrics, err := client.GetNodeMetricsByName(ctx, params.NodeName)
 		if err != nil {
-			if connectivity.IsError(err) {
+			if connectivity.IsTransportError(err) {
 				return response.Error(connectivity.ErrorMessage(err))
 			}
 			if isMetricsServerError(err) {
@@ -153,7 +153,7 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Always fetch all node metrics from the server
 	nodeMetricsList, err := client.GetNodeMetrics(ctx)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		if isMetricsServerError(err) {
@@ -276,7 +276,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -296,7 +296,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 
 		podMetrics, err := client.GetPodMetricsByName(ctx, params.Namespace, params.PodName)
 		if err != nil {
-			if connectivity.IsError(err) {
+			if connectivity.IsTransportError(err) {
 				return response.Error(connectivity.ErrorMessage(err))
 			}
 			if isMetricsServerError(err) {
@@ -327,7 +327,7 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	}
 
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		if isMetricsServerError(err) {

--- a/internal/handlers/metrics.go
+++ b/internal/handlers/metrics.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/connectivity"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/kubernetes"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/response"
 	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
@@ -115,6 +116,9 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to create client with context %q: %s", params.Context, err)
 	}
 
@@ -128,6 +132,9 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 		// Get specific node metrics
 		nodeMetrics, err := client.GetNodeMetricsByName(ctx, params.NodeName)
 		if err != nil {
+			if connectivity.IsError(err) {
+				return response.Error(connectivity.ErrorMessage(err))
+			}
 			if isMetricsServerError(err) {
 				return response.Errorf("%s", formatMetricsServerError(err))
 			}
@@ -146,6 +153,9 @@ func (h *MetricsHandler) GetNodeMetrics(ctx context.Context, request mcp.CallToo
 	// Always fetch all node metrics from the server
 	nodeMetricsList, err := client.GetNodeMetrics(ctx)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		if isMetricsServerError(err) {
 			return response.Errorf("%s", formatMetricsServerError(err))
 		}
@@ -266,6 +276,9 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
 	}
 
@@ -283,6 +296,9 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 
 		podMetrics, err := client.GetPodMetricsByName(ctx, params.Namespace, params.PodName)
 		if err != nil {
+			if connectivity.IsError(err) {
+				return response.Error(connectivity.ErrorMessage(err))
+			}
 			if isMetricsServerError(err) {
 				return response.Errorf("%s", formatMetricsServerError(err))
 			}
@@ -311,6 +327,9 @@ func (h *MetricsHandler) GetPodMetrics(ctx context.Context, request mcp.CallTool
 	}
 
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		if isMetricsServerError(err) {
 			return response.Errorf("%s", formatMetricsServerError(err))
 		}

--- a/internal/handlers/portforward.go
+++ b/internal/handlers/portforward.go
@@ -15,15 +15,20 @@ import (
 // PortForwardHandler provides MCP tools for managing port-forwarding sessions to Kubernetes pods.
 // It supports starting, stopping, and listing active port forwards with multiple port mappings per session.
 type PortForwardHandler struct {
-	client  *kubernetes.Client
-	manager *portforward.Manager
+	client      *kubernetes.Client
+	manager     *portforward.Manager
+	alwaysStart bool
 }
 
 // NewPortForwardHandler creates a new PortForwardHandler with the provided Kubernetes client and port-forward manager.
-func NewPortForwardHandler(client *kubernetes.Client, manager *portforward.Manager) *PortForwardHandler {
+// alwaysStart mirrors the --always-start flag: when true, connectivity and auth errors
+// are intercepted and returned as structured tool errors so the LLM can surface them
+// to the user rather than treating them as retryable failures.
+func NewPortForwardHandler(client *kubernetes.Client, manager *portforward.Manager, alwaysStart bool) *PortForwardHandler {
 	return &PortForwardHandler{
-		client:  client,
-		manager: manager,
+		client:      client,
+		manager:     manager,
+		alwaysStart: alwaysStart,
 	}
 }
 
@@ -72,7 +77,7 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
@@ -88,7 +93,7 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 		params.Context,
 	)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to start port forward: %w", err)

--- a/internal/handlers/portforward.go
+++ b/internal/handlers/portforward.go
@@ -72,7 +72,7 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
@@ -88,7 +88,7 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 		params.Context,
 	)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return nil, fmt.Errorf("failed to start port forward: %w", err)

--- a/internal/handlers/portforward.go
+++ b/internal/handlers/portforward.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/connectivity"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/kubernetes"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/portforward"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/response"
@@ -71,6 +72,9 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to create client with context %s: %w", params.Context, err)
 	}
 
@@ -84,6 +88,9 @@ func (h *PortForwardHandler) StartPortForward(ctx context.Context, request mcp.C
 		params.Context,
 	)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return nil, fmt.Errorf("failed to start port forward: %w", err)
 	}
 

--- a/internal/handlers/resources.go
+++ b/internal/handlers/resources.go
@@ -24,14 +24,19 @@ import (
 type ResourceHandler struct {
 	client         *kubernetes.Client
 	resourceFilter *resourcefilter.Filter
+	alwaysStart    bool
 }
 
 // NewResourceHandler creates a new ResourceHandler with the provided Kubernetes client
 // and an optional resource filter for blocking access to specific resource types.
-func NewResourceHandler(client *kubernetes.Client, filter *resourcefilter.Filter) *ResourceHandler {
+// alwaysStart mirrors the --always-start flag: when true, connectivity and auth errors
+// are intercepted and returned as structured tool errors so the LLM can surface them
+// to the user rather than treating them as retryable failures.
+func NewResourceHandler(client *kubernetes.Client, filter *resourcefilter.Filter, alwaysStart bool) *ResourceHandler {
 	return &ResourceHandler{
 		client:         client,
 		resourceFilter: filter,
+		alwaysStart:    alwaysStart,
 	}
 }
 
@@ -94,7 +99,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -102,7 +107,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 
 	gvr, err := client.ResolveResourceType(params.ResourceType, params.APIVersion)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if h.alwaysStart && connectivity.IsError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to resolve resource type: %v", err)
@@ -110,7 +115,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 
 	if h.resourceFilter != nil && h.resourceFilter.IsDisabled(gvr) {
 		if initErr := h.resourceFilter.InitError(); initErr != nil {
-			if connectivity.IsError(initErr) {
+			if h.alwaysStart && connectivity.IsError(initErr) {
 				return response.Error(connectivity.ErrorMessage(initErr))
 			}
 			return response.Errorf("resource filter could not be initialized: %v", initErr)
@@ -131,7 +136,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 
 	resources, err := client.ListResources(ctx, gvr, params.Namespace, listOptions)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to list resources: %v", err)
@@ -237,7 +242,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -245,7 +250,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 
 	gvr, err := client.ResolveResourceType(params.ResourceType, params.APIVersion)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if h.alwaysStart && connectivity.IsError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to resolve resource type: %v", err)
@@ -253,7 +258,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 
 	if h.resourceFilter != nil && h.resourceFilter.IsDisabled(gvr) {
 		if initErr := h.resourceFilter.InitError(); initErr != nil {
-			if connectivity.IsError(initErr) {
+			if h.alwaysStart && connectivity.IsError(initErr) {
 				return response.Error(connectivity.ErrorMessage(initErr))
 			}
 			return response.Errorf("resource filter could not be initialized: %v", initErr)
@@ -264,7 +269,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 
 	resource, err := client.GetResource(ctx, gvr, params.Namespace, params.Name)
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to get resource: %v", err)
@@ -415,7 +420,7 @@ func (h *ResourceHandler) ListAPIResources(ctx context.Context, request mcp.Call
 	}
 	lists, err := h.client.DiscoverResources(ctx)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if h.alwaysStart && connectivity.IsError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to discover API resources: %v", err)
@@ -425,7 +430,7 @@ func (h *ResourceHandler) ListAPIResources(ctx context.Context, request mcp.Call
 	// call below. Check for a prior init error before iterating.
 	if h.resourceFilter != nil {
 		if initErr := h.resourceFilter.InitError(); initErr != nil {
-			if connectivity.IsError(initErr) {
+			if h.alwaysStart && connectivity.IsError(initErr) {
 				return response.Error(connectivity.ErrorMessage(initErr))
 			}
 			return response.Errorf("resource filter could not be initialized: %v", initErr)
@@ -530,7 +535,7 @@ func (h *ResourceHandler) ListContexts(_ context.Context, request mcp.CallToolRe
 
 	contexts, err := h.client.ListContexts()
 	if err != nil {
-		if connectivity.IsTransportError(err) {
+		if h.alwaysStart && connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to list contexts: %v", err)

--- a/internal/handlers/resources.go
+++ b/internal/handlers/resources.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/connectivity"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/kubernetes"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/resourcefilter"
 	"github.com/patrickdappollonio/mcp-kubernetes-ro/internal/response"
@@ -93,15 +94,27 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
 	}
 
 	gvr, err := client.ResolveResourceType(params.ResourceType, params.APIVersion)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to resolve resource type: %v", err)
 	}
 
 	if h.resourceFilter != nil && h.resourceFilter.IsDisabled(gvr) {
+		if initErr := h.resourceFilter.InitError(); initErr != nil {
+			if connectivity.IsError(initErr) {
+				return response.Error(connectivity.ErrorMessage(initErr))
+			}
+			return response.Errorf("resource filter could not be initialized: %v", initErr)
+		}
 		return response.Errorf("access to resource %q (%s) is disabled by configuration and cannot be queried",
 			params.ResourceType, resourcefilter.FormatGVR(gvr))
 	}
@@ -118,6 +131,9 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 
 	resources, err := client.ListResources(ctx, gvr, params.Namespace, listOptions)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to list resources: %v", err)
 	}
 
@@ -221,21 +237,36 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
 	}
 
 	gvr, err := client.ResolveResourceType(params.ResourceType, params.APIVersion)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to resolve resource type: %v", err)
 	}
 
 	if h.resourceFilter != nil && h.resourceFilter.IsDisabled(gvr) {
+		if initErr := h.resourceFilter.InitError(); initErr != nil {
+			if connectivity.IsError(initErr) {
+				return response.Error(connectivity.ErrorMessage(initErr))
+			}
+			return response.Errorf("resource filter could not be initialized: %v", initErr)
+		}
 		return response.Errorf("access to resource %q (%s) is disabled by configuration and cannot be queried",
 			params.ResourceType, resourcefilter.FormatGVR(gvr))
 	}
 
 	resource, err := client.GetResource(ctx, gvr, params.Namespace, params.Name)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to get resource: %v", err)
 	}
 
@@ -384,7 +415,21 @@ func (h *ResourceHandler) ListAPIResources(ctx context.Context, request mcp.Call
 	}
 	lists, err := h.client.DiscoverResources(ctx)
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to discover API resources: %v", err)
+	}
+
+	// In lazy-filter mode, resolution is triggered by the first IsDisabled/MatchesAPIResource
+	// call below. Check for a prior init error before iterating.
+	if h.resourceFilter != nil {
+		if initErr := h.resourceFilter.InitError(); initErr != nil {
+			if connectivity.IsError(initErr) {
+				return response.Error(connectivity.ErrorMessage(initErr))
+			}
+			return response.Errorf("resource filter could not be initialized: %v", initErr)
+		}
 	}
 
 	// Determine whether to show title only (default to true)
@@ -485,6 +530,9 @@ func (h *ResourceHandler) ListContexts(_ context.Context, request mcp.CallToolRe
 
 	contexts, err := h.client.ListContexts()
 	if err != nil {
+		if connectivity.IsError(err) {
+			return response.Error(connectivity.ErrorMessage(err))
+		}
 		return response.Errorf("failed to list contexts: %v", err)
 	}
 

--- a/internal/handlers/resources.go
+++ b/internal/handlers/resources.go
@@ -94,7 +94,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -131,7 +131,7 @@ func (h *ResourceHandler) ListResources(ctx context.Context, request mcp.CallToo
 
 	resources, err := client.ListResources(ctx, gvr, params.Namespace, listOptions)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to list resources: %v", err)
@@ -237,7 +237,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 	// Use the appropriate client based on context
 	client, err := h.client.ForContext(params.Context)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to create client with context %s: %v", params.Context, err)
@@ -264,7 +264,7 @@ func (h *ResourceHandler) GetResource(ctx context.Context, request mcp.CallToolR
 
 	resource, err := client.GetResource(ctx, gvr, params.Namespace, params.Name)
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to get resource: %v", err)
@@ -530,7 +530,7 @@ func (h *ResourceHandler) ListContexts(_ context.Context, request mcp.CallToolRe
 
 	contexts, err := h.client.ListContexts()
 	if err != nil {
-		if connectivity.IsError(err) {
+		if connectivity.IsTransportError(err) {
 			return response.Error(connectivity.ErrorMessage(err))
 		}
 		return response.Errorf("failed to list contexts: %v", err)

--- a/internal/resourcefilter/filter.go
+++ b/internal/resourcefilter/filter.go
@@ -3,6 +3,7 @@ package resourcefilter
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -15,29 +16,109 @@ type ResourceResolver interface {
 }
 
 // Filter handles checking if Kubernetes resources are disabled by configuration.
+// It can operate in two modes:
+//
+//   - Eager mode (NewFilter): names are resolved at construction time. Any error
+//     (bad name, cluster unreachable) is returned immediately and the program
+//     should fail fast.
+//
+//   - Lazy mode (NewLazyFilter): name resolution is deferred to the first call
+//     to IsDisabled or MatchesAPIResource, using sync.Once. This is used with
+//     --always-start so that the server can start without a live cluster
+//     connection. If resolution fails at first use, InitError returns the error
+//     and callers are expected to surface it to the LLM.
 type Filter struct {
+	// resolved state (populated at construction in eager mode, or on first use
+	// in lazy mode)
 	disabled []schema.GroupVersionResource
 	raw      []string
+
+	// lazy-init fields; all zero-valued in eager mode
+	once     sync.Once
+	rawInput string           // original comma-separated input, stored for deferred parsing
+	resolver ResourceResolver // stored for deferred resolution
+	initErr  error            // error from deferred resolution
 }
 
-// NewFilter creates a new Filter from a comma/space-separated string of resource specs.
+// NewFilter creates a new Filter and eagerly resolves all resource specs against
+// the cluster API. Any parse or resolution error is returned immediately.
+//
 // Each spec can be either:
 //   - A resource name only (e.g., "secrets", "secret", "Secret", "po") which will be
 //     resolved using the provided resolver against all API versions.
 //   - A full group/version/resource triple (e.g., "core/v1/secrets", "apps/v1/deployments")
 //     where "core" is an alias for the empty core API group.
 //
-// The resolver is used to validate and canonicalize each spec (e.g., resolving singular
-// names to plural, kind names to resource names). Returns an error if any spec cannot
-// be parsed or resolved, since silently skipping a disabled resource is a security risk.
+// Returns an error if any spec cannot be parsed or resolved, since silently
+// skipping a disabled resource is a security risk.
 func NewFilter(value string, resolver ResourceResolver) (*Filter, error) {
+	f := &Filter{}
+	if err := f.resolve(value, resolver); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// NewLazyFilter creates a new Filter that defers name resolution to the first
+// call to IsDisabled or MatchesAPIResource. This allows the server to start
+// without a live cluster connection (--always-start mode).
+//
+// If the resolver is nil and value is non-empty, an error is returned
+// immediately since there is no way to ever resolve the specs.
+//
+// Parse errors (malformed spec strings) are also returned immediately since
+// they are not connectivity-dependent.
+func NewLazyFilter(value string, resolver ResourceResolver) (*Filter, error) {
 	if value == "" {
 		return &Filter{}, nil
 	}
 
-	tokens := strings.FieldsFunc(value, func(r rune) bool {
-		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
-	})
+	if resolver == nil {
+		return nil, fmt.Errorf("cannot create lazy resource filter: no resource resolver provided")
+	}
+
+	// Validate token syntax eagerly (no API call needed) so malformed input
+	// is caught at startup rather than silently at runtime.
+	if err := validateTokenSyntax(value); err != nil {
+		return nil, err
+	}
+
+	return &Filter{
+		rawInput: value,
+		resolver: resolver,
+	}, nil
+}
+
+// validateTokenSyntax checks that every token in value is either a bare name
+// or a "group/version/resource" triple. It does not make any API calls.
+func validateTokenSyntax(value string) error {
+	tokens := strings.FieldsFunc(value, isSeparator)
+	for _, token := range tokens {
+		parts := strings.Split(token, "/")
+		switch len(parts) {
+		case 1, 3:
+			// valid formats
+		default:
+			return fmt.Errorf("invalid disabled resource spec %q: expected \"resource\" or \"group/version/resource\" format (e.g. secrets or core/v1/secrets)", token)
+		}
+	}
+	return nil
+}
+
+// isSeparator reports whether r is a token separator character.
+func isSeparator(r rune) bool {
+	return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// resolve parses value and calls the resolver for each token, populating
+// f.disabled and f.raw. It is called directly by NewFilter (eager) and by
+// sync.Once in lazy mode.
+func (f *Filter) resolve(value string, resolver ResourceResolver) error {
+	if value == "" {
+		return nil
+	}
+
+	tokens := strings.FieldsFunc(value, isSeparator)
 
 	var disabled []schema.GroupVersionResource
 	var raw []string
@@ -66,30 +147,67 @@ func NewFilter(value string, resolver ResourceResolver) (*Filter, error) {
 				apiVersion = group + "/" + version
 			}
 		default:
-			return nil, fmt.Errorf("invalid disabled resource spec %q: expected \"resource\" or \"group/version/resource\" format (e.g. secrets or core/v1/secrets)", token)
+			return fmt.Errorf("invalid disabled resource spec %q: expected \"resource\" or \"group/version/resource\" format (e.g. secrets or core/v1/secrets)", token)
 		}
 
 		if resolver == nil {
-			return nil, fmt.Errorf("cannot validate disabled resource spec %q: no resource resolver available", token)
+			return fmt.Errorf("cannot validate disabled resource spec %q: no resource resolver available", token)
 		}
 
 		gvr, err := resolver.ResolveResourceType(resourceType, apiVersion)
 		if err != nil {
-			return nil, fmt.Errorf("cannot resolve disabled resource spec %q: %w", token, err)
+			return fmt.Errorf("cannot resolve disabled resource spec %q: %w", token, err)
 		}
 
 		disabled = append(disabled, gvr)
 		raw = append(raw, FormatGVR(gvr))
 	}
 
-	return &Filter{
-		disabled: disabled,
-		raw:      raw,
-	}, nil
+	f.disabled = disabled
+	f.raw = raw
+	return nil
+}
+
+// ensureResolved triggers lazy resolution on first use. In eager mode the
+// sync.Once func is never set, so this is a no-op there.
+func (f *Filter) ensureResolved() {
+	if f.rawInput == "" {
+		// Either eager mode (already resolved) or empty input — nothing to do.
+		return
+	}
+	f.once.Do(func() {
+		f.initErr = f.resolve(f.rawInput, f.resolver)
+	})
+}
+
+// InitError returns the error from deferred resolution, if any. Returns nil
+// in eager mode or when lazy resolution has not yet been attempted or
+// succeeded. Callers should check this after IsDisabled/MatchesAPIResource
+// returns false to distinguish "not disabled" from "filter not yet ready".
+//
+// In practice, the ResourceHandler checks this at the start of each tool
+// call so it can surface a meaningful connectivity error to the LLM.
+func (f *Filter) InitError() error {
+	if f == nil {
+		return nil
+	}
+	// Don't trigger resolution just to check the error — only report what
+	// has already been attempted.
+	return f.initErr
 }
 
 // IsDisabled checks if a given GroupVersionResource matches any disabled resource.
+// In lazy mode, this triggers resolution on first call.
+// If resolution has failed, this returns true (fail-closed: block all access
+// until the filter can be successfully initialized).
 func (f *Filter) IsDisabled(gvr schema.GroupVersionResource) bool {
+	f.ensureResolved()
+
+	// Fail-closed: if we couldn't resolve the filter, block access.
+	if f.initErr != nil {
+		return true
+	}
+
 	for _, d := range f.disabled {
 		if strings.EqualFold(d.Group, gvr.Group) &&
 			strings.EqualFold(d.Version, gvr.Version) &&
@@ -102,8 +220,16 @@ func (f *Filter) IsDisabled(gvr schema.GroupVersionResource) bool {
 
 // MatchesAPIResource checks if a discovered API resource should be filtered out.
 // The groupVersion parameter is the API group version string (e.g., "v1" for core,
-// "apps/v1" for apps group).
+// "apps/v1" for apps group). In lazy mode, this triggers resolution on first call.
+// If resolution has failed, this returns true (fail-closed).
 func (f *Filter) MatchesAPIResource(groupVersion, resourceName string) bool {
+	f.ensureResolved()
+
+	// Fail-closed: if we couldn't resolve the filter, block access.
+	if f.initErr != nil {
+		return true
+	}
+
 	gv, err := schema.ParseGroupVersion(groupVersion)
 	if err != nil {
 		return false
@@ -120,13 +246,23 @@ func (f *Filter) MatchesAPIResource(groupVersion, resourceName string) bool {
 }
 
 // HasDisabledResources returns true if any resources have been disabled.
+// In lazy mode this is based on the raw input string so it works before
+// resolution and without a cluster connection.
 func (f *Filter) HasDisabledResources() bool {
+	if f.rawInput != "" {
+		// Lazy mode: count non-empty tokens without resolving
+		return len(strings.FieldsFunc(f.rawInput, isSeparator)) > 0
+	}
 	return len(f.disabled) > 0
 }
 
-// GetDisabledResources returns the canonical string representations of disabled resources
-// in group/version/resource format (using "core" for the empty core API group).
+// GetDisabledResources returns the canonical string representations of disabled
+// resources in group/version/resource format (using "core" for the empty core
+// API group). In lazy mode, this triggers resolution — call only after
+// IsDisabled/MatchesAPIResource has already been called, or after confirming
+// InitError is nil.
 func (f *Filter) GetDisabledResources() []string {
+	f.ensureResolved()
 	result := make([]string, len(f.raw))
 	copy(result, f.raw)
 	return result

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ var (
 	disabledTools        stringSlice
 	disabledResources    stringSlice
 	enablePortForwarding = flag.Bool("enable-port-forwarding", false, "Enable port forwarding tools (start_port_forward, stop_port_forward, list_port_forwards)")
+	alwaysStart          = flag.Bool("always-start", false, "Skip the startup connectivity check and start the MCP server immediately. Useful for short-lived or browser-flow OIDC credentials that are not yet valid at process start. Connectivity and authentication errors will be reported as tool call failures instead of preventing startup.")
 	version              = "dev"
 )
 
@@ -86,6 +87,14 @@ func main() {
 		}
 	}
 
+	// Resolve always-start flag from CLI or environment variable
+	alwaysStartEnabled := *alwaysStart
+	if !alwaysStartEnabled {
+		if val := strings.TrimSpace(os.Getenv("MCP_KUBERNETES_RO_ALWAYS_START")); val != "" {
+			alwaysStartEnabled = strings.EqualFold(val, "true") || val == "1" || strings.EqualFold(val, "yes")
+		}
+	}
+
 	kubeConfig := &kubernetes.Config{
 		Kubeconfig: *kubeconfig,
 		Namespace:  *namespace,
@@ -96,27 +105,44 @@ func main() {
 		log.Fatalf("Failed to create Kubernetes client: %v", err)
 	}
 
-	// Test connectivity to the cluster to ensure we can operate otherwise
-	// prevent the MCP server from starting
-	fmt.Fprintln(os.Stderr, "Testing connectivity to Kubernetes cluster...")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	if err := client.TestConnectivity(ctx); err != nil {
-		cancel()
-		log.Fatalf("Failed to connect to Kubernetes cluster: %v\n\nPlease check:\n- Your kubeconfig file is valid\n- The cluster is accessible\n- You have the necessary RBAC permissions\n- The cluster is running and responding", err)
+	if alwaysStartEnabled {
+		// Skip the connectivity check and start immediately. Connectivity and
+		// authentication errors will be surfaced as tool call failures instead.
+		fmt.Fprintln(os.Stderr, "Skipping connectivity check (--always-start), starting MCP server immediately...")
+	} else {
+		// Test connectivity to the cluster to ensure we can operate, otherwise
+		// prevent the MCP server from starting.
+		fmt.Fprintln(os.Stderr, "Testing connectivity to Kubernetes cluster...")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := client.TestConnectivity(ctx); err != nil {
+			cancel()
+			log.Fatalf("Failed to connect to Kubernetes cluster: %v\n\nPlease check:\n- Your kubeconfig file is valid\n- The cluster is accessible\n- You have the necessary RBAC permissions\n- The cluster is running and responding", err)
+		}
+		cancel() // Clean up the context
+		fmt.Fprintln(os.Stderr, "Connected to Kubernetes cluster, starting MCP server...")
 	}
-	cancel() // Clean up the context
-	fmt.Fprintln(os.Stderr, "Connected to Kubernetes cluster, starting MCP server...")
 
 	// Create resource filter for disabled resources, using the client to
-	// resolve user-friendly names (singular, kind, short names) to canonical GVRs
-	resFilter, err := resourcefilter.NewFilter(strings.Join(disabledResources, ","), client)
+	// resolve user-friendly names (singular, kind, short names) to canonical GVRs.
+	// In --always-start mode the filter is lazy: name resolution is deferred to
+	// the first tool call so that a live cluster connection is not required at startup.
+	var resFilter *resourcefilter.Filter
+	if alwaysStartEnabled {
+		resFilter, err = resourcefilter.NewLazyFilter(strings.Join(disabledResources, ","), client)
+	} else {
+		resFilter, err = resourcefilter.NewFilter(strings.Join(disabledResources, ","), client)
+	}
 	if err != nil {
 		log.Fatalf("Failed to parse disabled resources: %v", err)
 	}
-	if resFilter.HasDisabledResources() {
+	if !alwaysStartEnabled && resFilter.HasDisabledResources() {
+		// In eager mode we can log the resolved canonical names immediately.
 		for _, res := range resFilter.GetDisabledResources() {
 			fmt.Fprintf(os.Stderr, "Disabling access to resource: %q\n", res)
 		}
+	} else if alwaysStartEnabled && resFilter.HasDisabledResources() {
+		// In lazy mode log the raw input; canonical names are resolved on first use.
+		fmt.Fprintf(os.Stderr, "Resource filter configured (will be applied on first tool call): %s\n", strings.Join(disabledResources, ", "))
 	}
 
 	// Define tools and handlers

--- a/main.go
+++ b/main.go
@@ -146,9 +146,9 @@ func main() {
 	}
 
 	// Define tools and handlers
-	resourceHandler := handlers.NewResourceHandler(client, resFilter)
-	logHandler := handlers.NewLogHandler(client)
-	metricsHandler := handlers.NewMetricsHandler(client)
+	resourceHandler := handlers.NewResourceHandler(client, resFilter, alwaysStartEnabled)
+	logHandler := handlers.NewLogHandler(client, alwaysStartEnabled)
+	metricsHandler := handlers.NewMetricsHandler(client, alwaysStartEnabled)
 	utilsHandler := handlers.NewUtilsHandler()
 
 	// Create port-forward manager (may be nil if not enabled)
@@ -203,7 +203,7 @@ func main() {
 	}
 
 	if portForwardingEnabled {
-		portForwardHandler := handlers.NewPortForwardHandler(client, pfManager)
+		portForwardHandler := handlers.NewPortForwardHandler(client, pfManager, alwaysStartEnabled)
 		allHandlers = append(allHandlers, portForwardHandler)
 	}
 


### PR DESCRIPTION
This introduces a new `--always-start` flag (and `MCP_KUBERNETES_RO_ALWAYS_START` env var) for environments where credentials are not yet valid when the MCP server process starts, such as with OIDC browser-flow authentication. Or alternatively, not wanting to be prompted to log in to Kubernetes just because I open a coding agent. 🙂 

Key changes:

- Lazy resource filter (`NewLazyFilter`): defers GVR name resolution to the first tool call so no cluster connection is needed at startup; syntax validation still runs eagerly
- Connectivity error detection (`internal/connectivity`): new `IsError`/`ErrorMessage` helpers that identify network, TLS, and auth failures and return a structured "do not retry" message to the LLM instead of a generic Go error
- All tool handlers (logs, metrics, port-forward, resources) now check `connectivity.IsError` on relevant errors and surface the structured message when a cluster is unreachable
- Documentation of startup connectivity check timeout corrected from 30s to 10s per code

Full disclosure - Claude Sonnet did all the heavy lifting, but the Go looked good and I've used this for a few days with it working as intended for my workflow.